### PR TITLE
Add version flag simplified

### DIFF
--- a/redli.go
+++ b/redli.go
@@ -61,6 +61,7 @@ var (
 )
 
 func main() {
+	kingpin.Version("0.4.5")
 	kingpin.Parse()
 
 	if *forceraw {


### PR DESCRIPTION
Add version support for the next release. Nothing to fancy but will print out the version with `--version`.