### PR TITLE
Support multiple version for AUTH backward compatible

### DIFF
--- a/redli.go
+++ b/redli.go
@@ -43,8 +43,9 @@ var (
 	redisurl      = kingpin.Flag("uri", "URI to connect to").Short('u').URL()
 	redishost     = kingpin.Flag("host", "Host to connect to").Short('h').Default("127.0.0.1").String()
 	redisport     = kingpin.Flag("port", "Port to connect to").Short('p').Default("6379").Int()
-	redisuser     = kingpin.Flag("redisuser", "Username to use when connecting. Supported since Redis 6.").Short('r').Default("default").String()
+	redisuser     = kingpin.Flag("redisuser", "Username to use when connecting. Supported since Redis 6.").Short('r').Default("").String()
 	redisauth     = kingpin.Flag("auth", "Password to use when connecting").Short('a').String()
+	redisversion  = kingpin.Flag("redisversion", "Version of Redis").Default("6").Int()
 	redisdb       = kingpin.Flag("ndb", "Redis database to access").Short('n').Default("0").Int()
 	redistls      = kingpin.Flag("tls", "Enable TLS/SSL").Default("false").Bool()
 	skipverify    = kingpin.Flag("skipverify", "Don't validate certificates").Default("false").Bool()
@@ -70,6 +71,12 @@ func main() {
 	} else {
 		if !isatty.IsTerminal(os.Stdout.Fd()) && !isatty.IsCygwinTerminal(os.Stdout.Fd()) {
 			raw = true
+		}
+	}
+
+	if "" == *redisuser {
+		if *redisversion >= 6 {
+			*redisuser = "default"
 		}
 	}
 
@@ -102,7 +109,6 @@ func main() {
 		if redisauth != nil {
 			connectionurl = connectionurl + url.QueryEscape(*redisuser) + ":" + url.QueryEscape(*redisauth) + "@"
 		}
-
 		connectionurl = connectionurl + *redishost + ":" + strconv.Itoa(*redisport) + "/" + strconv.Itoa(*redisdb)
 	} else {
 		connectionurl = (*redisurl).String()


### PR DESCRIPTION
Currently, the default user is `default` which cause redli issue `AUTH default <password>` on every server which was not compatible with Redis version < 6.
The work-around is using uri with empty `username`. eg: `redis://:<password>@localhost`