### PR TITLE
Dockerfile 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM golang:1.14-alpine as builder
+
+RUN apk add --no-cache ca-certificates git
+
+WORKDIR /src
+COPY go.mod ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a --ldflags '-s -w -extldflags "-static"' -tags netgo -installsuffix netgo -o ./redli
+
+
+FROM alpine:3.9
+RUN apk --no-cache add ca-certificates
+COPY --from=builder /src/redli /redli
+ENTRYPOINT ["/redli"]


### PR DESCRIPTION
Added a Dockerfile to build a Docker image of compiled `redli`.
This would facilitate:
- `redli` could be used on readonly hosts such as RancherOS, on various cloud providers
-  elimination of having to build `redli` and having a working and configured Go setup  

This PR doesn't include automatic, continues Docker-build and Docker-push of the resulting image, as this could only be done by the github repo owners, with, for example: [github actions for docker](https://github.com/marketplace/actions/build-and-push-docker-images)