### PR TITLE
chore: also build arm64 releases

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,6 +11,7 @@ builds:
     - linux
   goarch:
     - amd64
+    - arm64
 changelog:
   sort: asc
   filters:


### PR DESCRIPTION
Testing if existing build framework supports this function of goreleaser

resolves #47 