### PR TITLE
Add linux/s390x Support

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,6 +12,12 @@ builds:
   goarch:
     - amd64
     - arm64
+    - s390x
+  ignore:
+    - goos: darwin
+      goarch: s390x
+    - goos: windows
+      goarch: s390x
 changelog:
   sort: asc
   filters:


### PR DESCRIPTION
Hello!

We have some projects internal at HashiCorp (an IBM Company 😉) where we use `redli` at the moment and there are some use cases where we are exploring Z. As such it'd be great to have s390x builds of `redli` so we can avoid having to build it ourselves when/if that time comes! 

Thanks so much!